### PR TITLE
[BOPS-2341] Push to Docker Hub instead of GHCR

### DIFF
--- a/.github/workflows/build-test-push-images.yml
+++ b/.github/workflows/build-test-push-images.yml
@@ -43,36 +43,42 @@ jobs:
     name: "Ruby ${{ matrix.patch_version}} (${{ matrix.variant }}): Build, Test, Push"
     needs: define_matrix
     runs-on: ubuntu-22.04 # Avoids core dump issue introduced in ubuntu-24.04 (20250126.1.0)
-    permissions:
-      contents: read
-      packages: write
     strategy:
       fail-fast: false # Do not cancel every build if one fails
       matrix:
         include: ${{ fromJson(needs.define_matrix.outputs.matrix) }}
     env:
-      REGISTRY: ghcr.io
-      IMAGE_NAME: ${{ github.repository }}
+      IMAGE_NAME: ${{ github.repository }} # `ltvco/ruby-jemalloc`
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
 
-      - name: Log in to the container registry
+      - name: Load secrets
+        id: load_secrets
+        uses: ltvco/github-actions/aws-secret-loader@aws-secret-loader-v1
+        with:
+          map: |
+            docker-username:docker-username,
+            docker-token:docker-token
+          aws_access_key_id: ${{ secrets.GHA_AWS_ACCESS_KEY }}
+          aws_secret_access_key: ${{ secrets.GHA_AWS_SECRET_KEY }}
+          aws_secret_name: github-action-build-args
+
+      - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ steps.load_secrets.outputs.docker-username }}
+          password: ${{ steps.load_secrets.outputs.docker-token }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Determine specific variant tags
         run: |
-          # Ex: `ghcr.io/ltvco/ruby-jemalloc:3.3-bookworm`
-          echo "MINOR_VERSION_VARIANT_TAG=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.minor_version }}-${{ matrix.variant }}" >> $GITHUB_ENV
-          # Ex: `ghcr.io/ltvco/ruby-jemalloc:3.3.6-bookworm`
-          echo "PATCH_VERSION_VARIANT_TAG=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.patch_version }}-${{ matrix.variant }}" >> $GITHUB_ENV
+          # Ex: `ltvco/ruby-jemalloc:3.3-bookworm`
+          echo "MINOR_VERSION_VARIANT_TAG=${{ env.IMAGE_NAME }}:${{ matrix.minor_version }}-${{ matrix.variant }}" >> $GITHUB_ENV
+          # Ex: `ltvco/ruby-jemalloc:3.3.6-bookworm`
+          echo "PATCH_VERSION_VARIANT_TAG=${{ env.IMAGE_NAME }}:${{ matrix.patch_version }}-${{ matrix.variant }}" >> $GITHUB_ENV
 
       # Ref: https://docs.docker.com/build/ci/github-actions/test-before-push/
       - name: Build and export to local Docker cache
@@ -115,20 +121,20 @@ jobs:
       - name: Determine base variant tags
         run: |
           if [[ "${{ matrix.variant }}" == alpine* ]]; then
-            # Ex: `ghcr.io/ltvco/ruby-jemalloc:3.3-alpine`
-            MINOR_VERSION_BASE_TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.minor_version }}-alpine"
-            # Ex: `ghcr.io/ltvco/ruby-jemalloc:3.3.6-alpine`
-            PATCH_VERSION_BASE_TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.patch_version }}-alpine"
+            # Ex: `ltvco/ruby-jemalloc:3.3-alpine`
+            MINOR_VERSION_BASE_TAG="${{ env.IMAGE_NAME }}:${{ matrix.minor_version }}-alpine"
+            # Ex: `ltvco/ruby-jemalloc:3.3.6-alpine`
+            PATCH_VERSION_BASE_TAG="${{ env.IMAGE_NAME }}:${{ matrix.patch_version }}-alpine"
           elif [[ "${{ matrix.variant }}" == slim* ]]; then
-            # Ex: `ghcr.io/ltvco/ruby-jemalloc:3.3-slim`
-            MINOR_VERSION_BASE_TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.minor_version }}-slim"
-            # Ex: `ghcr.io/ltvco/ruby-jemalloc:3.3.6-slim`
-            PATCH_VERSION_BASE_TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.patch_version }}-slim"
+            # Ex: `ltvco/ruby-jemalloc:3.3-slim`
+            MINOR_VERSION_BASE_TAG="${{ env.IMAGE_NAME }}:${{ matrix.minor_version }}-slim"
+            # Ex: `ltvco/ruby-jemalloc:3.3.6-slim`
+            PATCH_VERSION_BASE_TAG="${{ env.IMAGE_NAME }}:${{ matrix.patch_version }}-slim"
           else
-            # Ex: `ghcr.io/ltvco/ruby-jemalloc:3.3`
-            MINOR_VERSION_BASE_TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.minor_version }}"
-            # Ex: `ghcr.io/ltvco/ruby-jemalloc:3.3.6`
-            PATCH_VERSION_BASE_TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.patch_version }}"
+            # Ex: `ltvco/ruby-jemalloc:3.3`
+            MINOR_VERSION_BASE_TAG="${{ env.IMAGE_NAME }}:${{ matrix.minor_version }}"
+            # Ex: `ltvco/ruby-jemalloc:3.3.6`
+            PATCH_VERSION_BASE_TAG="${{ env.IMAGE_NAME }}:${{ matrix.patch_version }}"
           fi
 
           echo "MINOR_VERSION_BASE_TAG=$MINOR_VERSION_BASE_TAG" >> $GITHUB_ENV


### PR DESCRIPTION
After considering the security and operational complexities with using GHCR we have decided to push to Docker Hub instead. The images will be pushed to `ltvco/ruby-jemalloc` and be public. We will phase out the old `ltvco/ruby`.

Ticket: https://ltvco.atlassian.net/browse/BOPS-2341