### PR TITLE
[BOPS-2341] Auth to Docker Hub with action secrets

### DIFF
--- a/.github/workflows/build-test-push-images.yml
+++ b/.github/workflows/build-test-push-images.yml
@@ -53,22 +53,11 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
-      - name: Load secrets
-        id: load_secrets
-        uses: ltvco/github-actions/aws-secret-loader@aws-secret-loader-v1
-        with:
-          map: |
-            docker-username:docker-username,
-            docker-token:docker-token
-          aws_access_key_id: ${{ secrets.GHA_AWS_ACCESS_KEY }}
-          aws_secret_access_key: ${{ secrets.GHA_AWS_SECRET_KEY }}
-          aws_secret_name: github-action-build-args
-
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ steps.load_secrets.outputs.docker-username }}
-          password: ${{ steps.load_secrets.outputs.docker-token }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
The previous approach of using the private `aws-secrets-loader` does not work as this repo is a public fork. This instead auths using GitHub Actions secrets.

Ref: https://docs.github.com/en/actions/sharing-automations/sharing-actions-and-workflows-from-your-private-repository
Ticket: https://ltvco.atlassian.net/browse/BOPS-2341