### PR TITLE
[BOPS-2737] Switch back to pushing to GHCR

### DIFF
--- a/.github/workflows/build-test-push-images.yml
+++ b/.github/workflows/build-test-push-images.yml
@@ -43,31 +43,36 @@ jobs:
     name: "Ruby ${{ matrix.patch_version}} (${{ matrix.variant }}): Build, Test, Push"
     needs: define_matrix
     runs-on: ubuntu-22.04 # Avoids core dump issue introduced in ubuntu-24.04 (20250126.1.0)
+    permissions:
+      contents: read
+      packages: write
     strategy:
       fail-fast: false # Do not cancel every build if one fails
       matrix:
         include: ${{ fromJson(needs.define_matrix.outputs.matrix) }}
     env:
-      IMAGE_NAME: ${{ github.repository }} # `ltvco/ruby-jemalloc`
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
 
-      - name: Log in to Docker Hub
+      - name: Log in to the container registry
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Determine specific variant tags
         run: |
-          # Ex: `ltvco/ruby-jemalloc:3.3-bookworm`
-          echo "MINOR_VERSION_VARIANT_TAG=${{ env.IMAGE_NAME }}:${{ matrix.minor_version }}-${{ matrix.variant }}" >> $GITHUB_ENV
-          # Ex: `ltvco/ruby-jemalloc:3.3.6-bookworm`
-          echo "PATCH_VERSION_VARIANT_TAG=${{ env.IMAGE_NAME }}:${{ matrix.patch_version }}-${{ matrix.variant }}" >> $GITHUB_ENV
+          # Ex: `ghcr.io/ltvco/ruby-jemalloc:3.3-bookworm`
+          echo "MINOR_VERSION_VARIANT_TAG=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.minor_version }}-${{ matrix.variant }}" >> $GITHUB_ENV
+          # Ex: `ghcr.io/ltvco/ruby-jemalloc:3.3.6-bookworm`
+          echo "PATCH_VERSION_VARIANT_TAG=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.patch_version }}-${{ matrix.variant }}" >> $GITHUB_ENV
 
       # Ref: https://docs.docker.com/build/ci/github-actions/test-before-push/
       - name: Build and export to local Docker cache
@@ -110,20 +115,20 @@ jobs:
       - name: Determine base variant tags
         run: |
           if [[ "${{ matrix.variant }}" == alpine* ]]; then
-            # Ex: `ltvco/ruby-jemalloc:3.3-alpine`
-            MINOR_VERSION_BASE_TAG="${{ env.IMAGE_NAME }}:${{ matrix.minor_version }}-alpine"
-            # Ex: `ltvco/ruby-jemalloc:3.3.6-alpine`
-            PATCH_VERSION_BASE_TAG="${{ env.IMAGE_NAME }}:${{ matrix.patch_version }}-alpine"
+            # Ex: `ghcr.io/ltvco/ruby-jemalloc:3.3-alpine`
+            MINOR_VERSION_BASE_TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.minor_version }}-alpine"
+            # Ex: `ghcr.io/ltvco/ruby-jemalloc:3.3.6-alpine`
+            PATCH_VERSION_BASE_TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.patch_version }}-alpine"
           elif [[ "${{ matrix.variant }}" == slim* ]]; then
-            # Ex: `ltvco/ruby-jemalloc:3.3-slim`
-            MINOR_VERSION_BASE_TAG="${{ env.IMAGE_NAME }}:${{ matrix.minor_version }}-slim"
-            # Ex: `ltvco/ruby-jemalloc:3.3.6-slim`
-            PATCH_VERSION_BASE_TAG="${{ env.IMAGE_NAME }}:${{ matrix.patch_version }}-slim"
+            # Ex: `ghcr.io/ltvco/ruby-jemalloc:3.3-slim`
+            MINOR_VERSION_BASE_TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.minor_version }}-slim"
+            # Ex: `ghcr.io/ltvco/ruby-jemalloc:3.3.6-slim`
+            PATCH_VERSION_BASE_TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.patch_version }}-slim"
           else
-            # Ex: `ltvco/ruby-jemalloc:3.3`
-            MINOR_VERSION_BASE_TAG="${{ env.IMAGE_NAME }}:${{ matrix.minor_version }}"
-            # Ex: `ltvco/ruby-jemalloc:3.3.6`
-            PATCH_VERSION_BASE_TAG="${{ env.IMAGE_NAME }}:${{ matrix.patch_version }}"
+            # Ex: `ghcr.io/ltvco/ruby-jemalloc:3.3`
+            MINOR_VERSION_BASE_TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.minor_version }}"
+            # Ex: `ghcr.io/ltvco/ruby-jemalloc:3.3.6`
+            PATCH_VERSION_BASE_TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.patch_version }}"
           fi
 
           echo "MINOR_VERSION_BASE_TAG=$MINOR_VERSION_BASE_TAG" >> $GITHUB_ENV


### PR DESCRIPTION
This reverts several commits related to changing the registry from GHCR
(how this was initially designed) to Dockerhub, as we had some issues
at the time related to enabling public GitHub packages.

We are now focused on transitioning off of Dockerhub, so we are
returning to the original strategy.

Reverts:
- https://github.com/ltvco/ruby-jemalloc/commit/6f2559a8c943f8bd30e4492051dd4baf483154ad
- https://github.com/ltvco/ruby-jemalloc/commit/5cca3648735a9dd567709fcea14162146206a474

Ticket: https://ltvco.atlassian.net/browse/BOPS-2737